### PR TITLE
Type legend persists on click

### DIFF
--- a/src/components/AtomeqElement.vue
+++ b/src/components/AtomeqElement.vue
@@ -72,10 +72,8 @@ onUnmounted(() => {
   card.value?.removeEventListener('mouseleave', resetCard);
   if (requestAnimationFrameId) cancelAnimationFrame(requestAnimationFrameId);
 });
-
-// TODO: Elements don't switch back when hovered on another type.
-// TODO: Bug with faded, not accounting for undefined. Should always be false in this case
 </script>
+
 <template>
   <div
     ref="card"

--- a/src/components/AtomeqTypeLegend.vue
+++ b/src/components/AtomeqTypeLegend.vue
@@ -25,7 +25,7 @@ const emits = defineEmits<{
   <div v-for="[parent, children] in getFormattedTypes()" :key="parent.id">
     <div
       :id="`parent-${parent.id}`"
-      class="bg-amber-500 border-2 p-2 text-sm text-center capitalize"
+      class="bg-amber-500 border-2 p-2 text-sm text-center capitalize cursor-pointer hover:bg-amber-200"
       @mouseover="emits('hover', parent)"
       @mouseleave="emits('hoverLeave', parent)"
       @click="emits('click', parent)"
@@ -36,7 +36,7 @@ const emits = defineEmits<{
       v-for="child in children"
       :key="child.id"
       :id="`child-${child.id}`"
-      class="bg-amber-700 border-2 p-2 text-xs text-center capitalize"
+      class="bg-amber-700 border-2 p-2 text-xs text-center capitalize cursor-pointer hover:bg-amber-500"
       @mouseover="emits('hover', child)"
       @mouseleave="emits('hoverLeave', child)"
       @click="emits('click', child)"

--- a/src/components/AtomeqTypeLegend.vue
+++ b/src/components/AtomeqTypeLegend.vue
@@ -16,11 +16,6 @@ const emits = defineEmits<{
 }>();
 </script>
 
-<!--TODO:
-  0. how do I want to handle the design? alignment
-  2. turn those into divs that on hover colour the correct section
--->
-
 <template>
   <div v-for="[parent, children] in getFormattedTypes()" :key="parent.id">
     <div

--- a/src/views/AtomeqTable.vue
+++ b/src/views/AtomeqTable.vue
@@ -62,7 +62,8 @@ onMounted(async () => {
 });
 
 /* * TODO:
- * 1. parents should highlight everything (all the children)
+ * 1. parents should highlight everything (all the children) -> push down the HIGHLIGHT to all the children (new test)
+ *    1.1 any cleanup/refactor? including tests that were written for the feature
  * 2. UI buttons should change colour themselves
  * 3. redesign the component
  * */

--- a/src/views/AtomeqTable.vue
+++ b/src/views/AtomeqTable.vue
@@ -64,8 +64,9 @@ onMounted(async () => {
 /* * TODO:
  * 1. parents should highlight everything (all the children) -> push down the HIGHLIGHT to all the children (new test)
  *    1.1 any cleanup/refactor? including tests that were written for the feature
- * 2. UI buttons should change colour themselves
- * 3. redesign the component
+ * 2. handle the deselecting things
+ * 3. UI buttons should change colour themselves
+ * 4. redesign the component
  * */
 
 const shouldFade = (element: Element): boolean => {

--- a/src/views/AtomeqTable.vue
+++ b/src/views/AtomeqTable.vue
@@ -4,7 +4,7 @@ import AtomeqTypeLegend from '@/components/AtomeqTypeLegend.vue';
 import { Element } from '@/types/element';
 import useElements from '@/composables/useElements.ts';
 import type { AtomeqElementType } from '@/types/elementType.ts';
-import { computed, onMounted, ref, watch } from 'vue';
+import { computed, onMounted, ref } from 'vue';
 import { getElementTable, getRadioactiveElementTable } from '@/helpers/tableUtils.ts';
 import { Display } from '@/types/atomeq-table.ts';
 import SwitchDisplay from '@/components/SwitchDisplay.vue';
@@ -60,6 +60,12 @@ const displayColour = (element: Element) => {
 onMounted(async () => {
   await getElements();
 });
+
+/* * TODO:
+ * 1. parents should highlight everything (all the children)
+ * 2. UI buttons should change colour themselves
+ * 3. redesign the component
+ * */
 
 const shouldFade = (element: Element): boolean => {
   const isHovered = hoveredType.value && hoveredType.value.id === element.typeId;

--- a/src/views/AtomeqTable.vue
+++ b/src/views/AtomeqTable.vue
@@ -13,7 +13,7 @@ import AtomeqElementModal from '@/components/modals/AtomeqElementModal.vue';
 const elementDisplay = ref<Display>(Display.TYPE);
 const selectedElement = ref<Element | undefined>(undefined);
 const hoveredType = ref<AtomeqElementType | undefined>(undefined);
-const selectedTypes = ref<AtomeqElementType[]>([]);
+const selectedTypes = ref<number[]>([]);
 
 const { getElements, elements } = useElements();
 
@@ -82,7 +82,7 @@ watch(selectedTypes.value, (newVal, oldVal) => {
         v-if="elementDisplay === Display.TYPE"
         @hover="hoveredType = $event"
         @hoverLeave="hoveredType = undefined"
-        @click="selectedTypes.push($event)"
+        @click="selectedTypes.push($event.id)"
       />
     </div>
     <div :key="idx" v-for="(row, idx) in elementTable" class="grid grid-cols-18 gap-1">
@@ -94,7 +94,7 @@ watch(selectedTypes.value, (newVal, oldVal) => {
           :element="element"
           :faded="
             (hoveredType && hoveredType.id !== element.typeId) ||
-            (selectedTypes.length > 0 && !selectedTypes.includes(element.type!))
+            (selectedTypes.length > 0 && !selectedTypes.includes(element.typeId))
           "
           @click="selectedElement = element"
         />
@@ -109,7 +109,7 @@ watch(selectedTypes.value, (newVal, oldVal) => {
             :element="element"
             :faded="
               (hoveredType && hoveredType.id !== element.typeId) ||
-              (selectedTypes.length > 0 && !selectedTypes.includes(element.type!)) // TODO: compare ids
+              (selectedTypes.length > 0 && !selectedTypes.includes(element.typeId))
             "
             @click="selectedElement = element"
           />

--- a/src/views/AtomeqTable.vue
+++ b/src/views/AtomeqTable.vue
@@ -61,27 +61,25 @@ onMounted(async () => {
   await getElements();
 });
 
+// SHOULD FADE IF I AM:
+//   - NOT DEFAULT
+//   - NOT HOVERED
+//   - NOT SELECTED
+//   - AND IF ANYTHING WAS SELECTED, ONLY SELECTED SHOULD BE HIGHLIGHTED
+//   - AND SELECTED SHOULD PERSIST, IF SELECTED, WHEN HOVERED
 const shouldFade = (element: Element): boolean => {
   const isHovered = hoveredType.value && hoveredType.value.id === element.typeId;
   const isSelected = selectedTypes.value.length > 0 && selectedTypes.value.includes(element.typeId);
 
-  return !isHovered && !isSelected;
+  if ((hoveredType.value || selectedTypes.value.length > 0) && !isHovered && !isSelected) {
+    return true;
+  }
 
-  // if (!hoveredType.value) {
-  //   return false;
-  // }
-  //
-  // if (hoveredType.value && hoveredType.value.id !== element.typeId) {
-  //   return false;
-  // }
-  //
-  // if (selectedTypes.value.length > 0 && !selectedTypes.value.includes(element.typeId)) {
-  //   return false;
-  // }
-  // // (hoveredType.value && hoveredType.value.id !== element.typeId) ||
-  // //   (selectedTypes.value.length > 0 && !selectedTypes.value.includes(element.typeId));
-  //
-  // return true;
+  if (!hoveredType.value) {
+    return false;
+  }
+
+  return false;
 };
 </script>
 

--- a/src/views/AtomeqTable.vue
+++ b/src/views/AtomeqTable.vue
@@ -4,7 +4,7 @@ import AtomeqTypeLegend from '@/components/AtomeqTypeLegend.vue';
 import { Element } from '@/types/element';
 import useElements from '@/composables/useElements.ts';
 import type { AtomeqElementType } from '@/types/elementType.ts';
-import { computed, onMounted, ref } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import { getElementTable, getRadioactiveElementTable } from '@/helpers/tableUtils.ts';
 import { Display } from '@/types/atomeq-table.ts';
 import SwitchDisplay from '@/components/SwitchDisplay.vue';
@@ -13,6 +13,7 @@ import AtomeqElementModal from '@/components/modals/AtomeqElementModal.vue';
 const elementDisplay = ref<Display>(Display.TYPE);
 const selectedElement = ref<Element | undefined>(undefined);
 const hoveredType = ref<AtomeqElementType | undefined>(undefined);
+const selectedTypes = ref<AtomeqElementType[]>([]);
 
 const { getElements, elements } = useElements();
 
@@ -59,6 +60,10 @@ const displayColour = (element: Element) => {
 onMounted(async () => {
   await getElements();
 });
+
+watch(selectedTypes.value, (newVal, oldVal) => {
+  console.log(newVal, oldVal);
+});
 </script>
 
 <template>
@@ -77,6 +82,7 @@ onMounted(async () => {
         v-if="elementDisplay === Display.TYPE"
         @hover="hoveredType = $event"
         @hoverLeave="hoveredType = undefined"
+        @click="selectedTypes.push($event)"
       />
     </div>
     <div :key="idx" v-for="(row, idx) in elementTable" class="grid grid-cols-18 gap-1">
@@ -86,7 +92,10 @@ onMounted(async () => {
           class="border-2 rounded h-20 shadow-md p-1 cursor-pointer"
           :class="displayColour(element)"
           :element="element"
-          :faded="hoveredType && hoveredType.id !== element.typeId"
+          :faded="
+            (hoveredType && hoveredType.id !== element.typeId) ||
+            (selectedTypes.length > 0 && !selectedTypes.includes(element.type!))
+          "
           @click="selectedElement = element"
         />
       </div>
@@ -98,7 +107,10 @@ onMounted(async () => {
             class="border-2 rounded h-20 shadow-md mb-1 p-1 cursor-pointer"
             :class="displayColour(element)"
             :element="element"
-            :faded="hoveredType && hoveredType?.id !== element.typeId"
+            :faded="
+              (hoveredType && hoveredType.id !== element.typeId) ||
+              (selectedTypes.length > 0 && !selectedTypes.includes(element.type!)) // TODO: compare ids
+            "
             @click="selectedElement = element"
           />
         </div>

--- a/src/views/AtomeqTable.vue
+++ b/src/views/AtomeqTable.vue
@@ -61,25 +61,11 @@ onMounted(async () => {
   await getElements();
 });
 
-// SHOULD FADE IF I AM:
-//   - NOT DEFAULT
-//   - NOT HOVERED
-//   - NOT SELECTED
-//   - AND IF ANYTHING WAS SELECTED, ONLY SELECTED SHOULD BE HIGHLIGHTED
-//   - AND SELECTED SHOULD PERSIST, IF SELECTED, WHEN HOVERED
 const shouldFade = (element: Element): boolean => {
   const isHovered = hoveredType.value && hoveredType.value.id === element.typeId;
   const isSelected = selectedTypes.value.length > 0 && selectedTypes.value.includes(element.typeId);
 
-  if ((hoveredType.value || selectedTypes.value.length > 0) && !isHovered && !isSelected) {
-    return true;
-  }
-
-  if (!hoveredType.value) {
-    return false;
-  }
-
-  return false;
+  return (hoveredType.value || selectedTypes.value.length > 0) && !isHovered && !isSelected;
 };
 </script>
 

--- a/src/views/AtomeqTable.vue
+++ b/src/views/AtomeqTable.vue
@@ -61,9 +61,28 @@ onMounted(async () => {
   await getElements();
 });
 
-watch(selectedTypes.value, (newVal, oldVal) => {
-  console.log(newVal, oldVal);
-});
+const shouldFade = (element: Element): boolean => {
+  const isHovered = hoveredType.value && hoveredType.value.id === element.typeId;
+  const isSelected = selectedTypes.value.length > 0 && selectedTypes.value.includes(element.typeId);
+
+  return !isHovered && !isSelected;
+
+  // if (!hoveredType.value) {
+  //   return false;
+  // }
+  //
+  // if (hoveredType.value && hoveredType.value.id !== element.typeId) {
+  //   return false;
+  // }
+  //
+  // if (selectedTypes.value.length > 0 && !selectedTypes.value.includes(element.typeId)) {
+  //   return false;
+  // }
+  // // (hoveredType.value && hoveredType.value.id !== element.typeId) ||
+  // //   (selectedTypes.value.length > 0 && !selectedTypes.value.includes(element.typeId));
+  //
+  // return true;
+};
 </script>
 
 <template>
@@ -92,10 +111,7 @@ watch(selectedTypes.value, (newVal, oldVal) => {
           class="border-2 rounded h-20 shadow-md p-1 cursor-pointer"
           :class="displayColour(element)"
           :element="element"
-          :faded="
-            (hoveredType && hoveredType.id !== element.typeId) ||
-            (selectedTypes.length > 0 && !selectedTypes.includes(element.typeId))
-          "
+          :faded="shouldFade(element)"
           @click="selectedElement = element"
         />
       </div>
@@ -107,10 +123,7 @@ watch(selectedTypes.value, (newVal, oldVal) => {
             class="border-2 rounded h-20 shadow-md mb-1 p-1 cursor-pointer"
             :class="displayColour(element)"
             :element="element"
-            :faded="
-              (hoveredType && hoveredType.id !== element.typeId) ||
-              (selectedTypes.length > 0 && !selectedTypes.includes(element.typeId))
-            "
+            :faded="shouldFade(element)"
             @click="selectedElement = element"
           />
         </div>

--- a/src/views/__tests__/AtomeqTable.spec.ts
+++ b/src/views/__tests__/AtomeqTable.spec.ts
@@ -241,4 +241,37 @@ describe('AtomeqTable', () => {
       expect(element.props('faded')).toEqual(true);
     });
   });
+
+  // TODO:
+  // 1. chech that on hover and on click the children types are highlighted if the parent is clicked/hovered
+  // 2. data provider for hover/click? similar test, different emits
+
+  // it('will highlight the children types if the parent type is hovered', async () => {
+  //   apiService.fetchElements.mockResolvedValue(mockElements as AxiosResponse);
+  //   const nobleGas = mockTypes.data.find((item) => item.name === 'noble-gas');
+  //
+  //   const wrapper = mount(AtomeqTable);
+  //   await flushPromises();
+  //
+  //   const typeLegend = wrapper.findComponent(AtomeqTypeLegend);
+  //   typeLegend.vm.$emit('click', nobleGas);
+  //   await nextTick();
+  //
+  //   const allElements = wrapper.findAllComponents(AtomeqElement);
+  //
+  //   const nobleGasElements = allElements.filter(
+  //     (item) => item.props('element').typeId === nobleGas?.id,
+  //   );
+  //   const otherElements = allElements.filter(
+  //     (item) => item.props('element').typeId !== nobleGas?.id,
+  //   );
+  //
+  //   nobleGasElements.forEach((element) => {
+  //     expect(element.props('faded')).toEqual(false);
+  //   });
+  //
+  //   otherElements.forEach((element) => {
+  //     expect(element.props('faded')).toEqual(true);
+  //   });
+  // });
 });

--- a/src/views/__tests__/AtomeqTable.spec.ts
+++ b/src/views/__tests__/AtomeqTable.spec.ts
@@ -168,4 +168,33 @@ describe('AtomeqTable', () => {
       expect(element.props('faded')).toEqual(false);
     });
   });
+
+  it('will persist the highlighted state when the legend type is clicked', async () => {
+    apiService.fetchElements.mockResolvedValue(mockElements as AxiosResponse);
+    const nobleGas = mockTypes.data.find((item) => item.name === 'noble-gas');
+
+    const wrapper = mount(AtomeqTable);
+    await flushPromises();
+
+    const typeLegend = wrapper.findComponent(AtomeqTypeLegend);
+    typeLegend.vm.$emit('click', nobleGas);
+    await nextTick();
+
+    const allElements = wrapper.findAllComponents(AtomeqElement);
+
+    const nobleGasElements = allElements.filter(
+      (item) => item.props('element').typeId === nobleGas?.id,
+    );
+    const otherElements = allElements.filter(
+      (item) => item.props('element').typeId !== nobleGas?.id,
+    );
+
+    nobleGasElements.forEach((element) => {
+      expect(element.props('faded')).toEqual(false);
+    });
+
+    otherElements.forEach((element) => {
+      expect(element.props('faded')).toEqual(true);
+    });
+  });
 });

--- a/src/views/__tests__/AtomeqTable.spec.ts
+++ b/src/views/__tests__/AtomeqTable.spec.ts
@@ -197,4 +197,48 @@ describe('AtomeqTable', () => {
       expect(element.props('faded')).toEqual(true);
     });
   });
+
+  it('will persist highlighting when an element type is selected and another type is hovered', async () => {
+    apiService.fetchElements.mockResolvedValue(mockElements as AxiosResponse);
+    const nobleGas = mockTypes.data.find((item) => item.name === 'noble-gas');
+    const transitionMetal = mockTypes.data.find((item) => item.name === 'transition-metal');
+
+    const wrapper = mount(AtomeqTable);
+    await flushPromises();
+
+    const typeLegend = wrapper.findComponent(AtomeqTypeLegend);
+    typeLegend.vm.$emit('click', nobleGas);
+    await nextTick();
+
+    typeLegend.vm.$emit('hover', transitionMetal);
+    await nextTick();
+
+    const allElements = wrapper.findAllComponents(AtomeqElement);
+
+    const nobleGasElements = allElements.filter(
+      (item) => item.props('element').typeId === nobleGas?.id,
+    );
+
+    const transitionMetalElements = allElements.filter(
+      (item) => item.props('element').typeId === transitionMetal?.id,
+    );
+
+    const otherElements = allElements.filter(
+      (item) =>
+        item.props('element').typeId !== nobleGas?.id &&
+        item.props('element').typeId !== transitionMetal?.id,
+    );
+
+    nobleGasElements.forEach((element) => {
+      expect(element.props('faded')).toEqual(false);
+    });
+
+    transitionMetalElements.forEach((element) => {
+      expect(element.props('faded')).toEqual(false);
+    });
+
+    otherElements.forEach((element) => {
+      expect(element.props('faded')).toEqual(true);
+    });
+  });
 });

--- a/src/views/__tests__/AtomeqTable.spec.ts
+++ b/src/views/__tests__/AtomeqTable.spec.ts
@@ -246,32 +246,32 @@ describe('AtomeqTable', () => {
   // 1. chech that on hover and on click the children types are highlighted if the parent is clicked/hovered
   // 2. data provider for hover/click? similar test, different emits
 
-  // it('will highlight the children types if the parent type is hovered', async () => {
-  //   apiService.fetchElements.mockResolvedValue(mockElements as AxiosResponse);
-  //   const nobleGas = mockTypes.data.find((item) => item.name === 'noble-gas');
-  //
-  //   const wrapper = mount(AtomeqTable);
-  //   await flushPromises();
-  //
-  //   const typeLegend = wrapper.findComponent(AtomeqTypeLegend);
-  //   typeLegend.vm.$emit('click', nobleGas);
-  //   await nextTick();
-  //
-  //   const allElements = wrapper.findAllComponents(AtomeqElement);
-  //
-  //   const nobleGasElements = allElements.filter(
-  //     (item) => item.props('element').typeId === nobleGas?.id,
-  //   );
-  //   const otherElements = allElements.filter(
-  //     (item) => item.props('element').typeId !== nobleGas?.id,
-  //   );
-  //
-  //   nobleGasElements.forEach((element) => {
-  //     expect(element.props('faded')).toEqual(false);
-  //   });
-  //
-  //   otherElements.forEach((element) => {
-  //     expect(element.props('faded')).toEqual(true);
-  //   });
-  // });
+  it.skip('will highlight the children types if the parent type is hovered', async () => {
+    apiService.fetchElements.mockResolvedValue(mockElements as AxiosResponse);
+    const nobleGas = mockTypes.data.find((item) => item.name === 'noble-gas');
+
+    const wrapper = mount(AtomeqTable);
+    await flushPromises();
+
+    const typeLegend = wrapper.findComponent(AtomeqTypeLegend);
+    typeLegend.vm.$emit('click', nobleGas);
+    await nextTick();
+
+    const allElements = wrapper.findAllComponents(AtomeqElement);
+
+    const nobleGasElements = allElements.filter(
+      (item) => item.props('element').typeId === nobleGas?.id,
+    );
+    const otherElements = allElements.filter(
+      (item) => item.props('element').typeId !== nobleGas?.id,
+    );
+
+    nobleGasElements.forEach((element) => {
+      expect(element.props('faded')).toEqual(false);
+    });
+
+    otherElements.forEach((element) => {
+      expect(element.props('faded')).toEqual(true);
+    });
+  });
 });


### PR DESCRIPTION
This PR includes the functionality that allows the types to be highlighted based off of whether a certain type on the Atomeq Legend was highlighted. 

Subsequent PRs will be addressing the design portion of the work, as well as an incremental iteration/hotfix on highlighting children types if the parent type was hovered/selected.